### PR TITLE
Add development tools and pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+repos:
+  - repo: https://github.com/psf/black
+    rev: 24.4.2
+    hooks:
+      - id: black
+  - repo: https://github.com/pycqa/flake8
+    rev: 7.3.0
+    hooks:
+      - id: flake8

--- a/README.md
+++ b/README.md
@@ -28,3 +28,16 @@ python scripts/openrouter_eval.py
 ```
 
 Make sure `OPENROUTER_API_KEY` is set in the environment to allow API access.
+
+## Development setup
+
+Install runtime requirements and the additional development tools:
+
+```bash
+pip install -r requirements.txt
+pip install -r requirements-dev.txt
+pre-commit install
+```
+
+With the hooks installed, formatting and lint checks are run automatically on
+each commit.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+black
+flake8
+pre-commit


### PR DESCRIPTION
## Summary
- add `requirements-dev.txt` for dev dependencies
- create `.pre-commit-config.yaml` running black and flake8
- document setup of dev tools in README

## Testing
- `pre-commit run --files README.md requirements-dev.txt .pre-commit-config.yaml`

------
https://chatgpt.com/codex/tasks/task_e_687d05f68390832992ba7555f08d4de9