### PR TITLE
Add env-based config for evaluation scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,18 @@ python scripts/openrouter_eval.py
 ```
 
 Make sure `OPENROUTER_API_KEY` is set in the environment to allow API access.
+
+To evaluate a local model instead, execute `round_test.sh`. When `USE_OPENROUTER=true` is set the script will invoke `openrouter_eval.py`; otherwise it runs the local inference scripts bundled in this repository.
+
+## Environment variables
+
+Several scripts read configuration from environment variables:
+
+- `MODEL_NAME` – model identifier or path. Used by both `round_test.sh` and `openrouter_eval.py`.
+- `INPUT_PATH` – path to the evaluation dataset. Defaults to `./input/math.jsonl`.
+- `OUTPUT_BASE_DIR` – directory in which result files are created. Defaults to `./output/${EXPERIMENT_ID}`.
+- `EXPERIMENT_ID` – experiment name appended to output files. Defaults to `basemodel`.
+- `TEMPERATURE` – sampling temperature (default `0`).
+- `LORA` and `GPU_MEMORY_UTILIZATION` – options for local evaluation scripts.
+- `USE_OPENROUTER` – if set to `true`, `round_test.sh` runs `openrouter_eval.py` instead of local scripts.
+- `INFO_LOG_FILE` – log file path (default `${OUTPUT_BASE_DIR}/info.txt`).

--- a/round_test.sh
+++ b/round_test.sh
@@ -1,32 +1,41 @@
 #!/bin/sh
 
 ARRAY=(main zeroshot instruct_format_ja instruct_format_en instruct_format_mix step_by_step_ja step_by_step_en step_by_step_mix roleplay_ja roleplay_en deep_breath_ja deep_breath_en re-read_ja re-read_en re-read_mix echo_ja echo_en step_back_ja)
-number="basemodel"
-model="llm-jp/llm-jp-3-13b-instruct2"
-input="./input/math.jsonl"
-lora=False
-gpu=0.9
-temperature=0
 
-output_home="./output/$number"
+# Experiment name used for output file names.
+EXPERIMENT_ID="${EXPERIMENT_ID:-basemodel}"
+# Model path or identifier. Can be overridden with the MODEL_NAME environment variable.
+MODEL_NAME="${MODEL_NAME:-llm-jp/llm-jp-3-13b-instruct2}"
+# Path to the input dataset.
+INPUT_PATH="${INPUT_PATH:-./input/math.jsonl}"
+LORA="${LORA:-False}"
+GPU_MEMORY_UTILIZATION="${GPU_MEMORY_UTILIZATION:-0.9}"
+TEMPERATURE="${TEMPERATURE:-0}"
 
-if [ -e ${output_home} ]; then
-  echo "${output_home}は存在します。"
+# Base directory for outputs
+OUTPUT_BASE_DIR="${OUTPUT_BASE_DIR:-./output/${EXPERIMENT_ID}}"
+
+if [ -e "${OUTPUT_BASE_DIR}" ]; then
+  echo "${OUTPUT_BASE_DIR}は存在します。"
 else
-  mkdir "${output_home}"
-  echo "${output_home}を作成しました。"
+  mkdir -p "${OUTPUT_BASE_DIR}"
+  echo "${OUTPUT_BASE_DIR}を作成しました。"
 fi
 
-INFO_LOG_FILE="${output_home}/info.txt"
+INFO_LOG_FILE="${INFO_LOG_FILE:-${OUTPUT_BASE_DIR}/info.txt}"
 
-for arg in ${ARRAY[@]}
-do
-  output_dir="${output_home}/${arg}-${number}.jsonl"
-  python scripts/$arg.py $model \
-  --input_path=$input \
-  --output_path=$output_dir \
-  --enable_lora=$lora \
-  --gpu_memory_utilization=$gpu \
-  --temperature=$temperature
-  python scripts/eval.py --input_path=$output_dir --log_path=$INFO_LOG_FILE
-done
+if [ "${USE_OPENROUTER}" = "true" ]; then
+  python scripts/openrouter_eval.py
+else
+  for arg in ${ARRAY[@]}
+  do
+    output_dir="${OUTPUT_BASE_DIR}/${arg}-${EXPERIMENT_ID}.jsonl"
+    python scripts/$arg.py "$MODEL_NAME" \
+      --input_path="$INPUT_PATH" \
+      --output_path="$output_dir" \
+      --enable_lora="$LORA" \
+      --gpu_memory_utilization="$GPU_MEMORY_UTILIZATION" \
+      --temperature="$TEMPERATURE"
+    python scripts/eval.py --input_path="$output_dir" --log_path="$INFO_LOG_FILE"
+  done
+fi


### PR DESCRIPTION
## Summary
- make `round_test.sh` configurable via environment variables
- optionally run `openrouter_eval.py` when `USE_OPENROUTER=true`
- document environment variables used by scripts

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687d0506670c832998e878ee68269076