### PR TITLE
Fix is_equiv exception handling and add tests

### DIFF
--- a/scripts/eval.py
+++ b/scripts/eval.py
@@ -153,7 +153,7 @@ def is_equiv(str1, str2, verbose=False):
             print(ss1, ss2)
         return ss1 == ss2
     except:
-        return str1 
+        return False
 
 import json
 from urllib import response

--- a/scripts/openrouter_eval.py
+++ b/scripts/openrouter_eval.py
@@ -116,7 +116,7 @@ def is_equiv(str1, str2, verbose=False):
             print(ss1, ss2)
         return ss1 == ss2
     except Exception:
-        return str1
+        return False
 
 def extract_boxed_answer_rev(text: str) -> str:
     key = r"\\boxed{"

--- a/tests/test_is_equiv.py
+++ b/tests/test_is_equiv.py
@@ -1,0 +1,14 @@
+import os
+import sys
+import pytest
+
+# Ensure scripts package is importable
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from scripts.eval import is_equiv as eval_is_equiv
+from scripts.openrouter_eval import is_equiv as router_is_equiv
+
+@pytest.mark.parametrize("func", [eval_is_equiv, router_is_equiv])
+def test_invalid_input_returns_false(func):
+    assert func(1, "1") is False
+    assert func("1", 1) is False


### PR DESCRIPTION
## Summary
- return `False` in `is_equiv` when `_strip_string` fails
- add `__init__.py` so `scripts` can be imported in tests
- add minimal unit tests verifying invalid inputs are not treated as correct

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687d051597c88329970806504396d7e1