### PR TITLE
Update README with OpenRouter usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,25 @@ export INPUT_PATH=/eval/input/math.jsonl
 export OUTPUT_BASE_DIR=/eval/output/${EXPERIMENT_ID}
 export INFO_LOG_FILE=${OUTPUT_BASE_DIR}/info.txt
 export TEMPERATURE=0
+export OPENROUTER_API_KEY=your_openrouter_key
 python scripts/openrouter_eval.py
 ```
 
 Make sure `OPENROUTER_API_KEY` is set in the environment to allow API access.
+
+## OpenRouter evaluation with round_test.sh
+
+`round_test.sh` can be modified to call `scripts/openrouter_eval.py` so that multiple evaluation prompts are executed in sequence. Example environment setup:
+
+```bash
+export MODEL_NAME=qwen/qwen3-32b:free
+export INPUT_PATH=/eval/input/math.jsonl
+export EXPERIMENT_ID=basemodel
+export OUTPUT_BASE_DIR=/eval/output/${EXPERIMENT_ID}
+export INFO_LOG_FILE=${OUTPUT_BASE_DIR}/info.txt
+export TEMPERATURE=0
+export OPENROUTER_API_KEY=your_openrouter_key
+./round_test.sh
+```
+
+The script will generate one output file for each prompt in the array and log the overall accuracy.


### PR DESCRIPTION
## Summary
- show how to run `round_test.sh` with OpenRouter
- document required environment variables

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687d0524e2e48329b188811149ca9223