### PR TITLE
Add USE_OPENROUTER option and env-based configs

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,18 +13,39 @@ python scripts/prepare_math_dataset.py
 
 ## Running evaluation
 
-`scripts/openrouter_eval.py` runs inference using OpenRouter and logs the accuracy. The script reads configuration from environment variables such as `MODEL_NAME`, `OUTPUT_BASE_DIR` and `INFO_LOG_FILE`.
+Evaluation behavior is controlled entirely through environment variables.
 
-Example:
+### Required variables
+
+- `MODEL_NAME` – Local model path or OpenRouter model identifier.
+- `INPUT_PATH` – Path to the JSONL dataset.
+- `OUTPUT_BASE_DIR` – Directory where outputs are written.
+- `EXPERIMENT_ID` – Label appended to output files.
+- `INFO_LOG_FILE` – Log file path (defaults to `$OUTPUT_BASE_DIR/info.txt`).
+- `TEMPERATURE` – Sampling temperature.
+- `USE_OPENROUTER` – When set to `true`, `scripts/openrouter_eval.py` is used. Otherwise the local scripts are run.
+- `OPENROUTER_API_KEY` – Required only when `USE_OPENROUTER=true`.
+
+### Example (OpenRouter)
 
 ```bash
+export USE_OPENROUTER=true
 export EXPERIMENT_ID=basemodel
 export MODEL_NAME=qwen/qwen3-32b:free
 export INPUT_PATH=/eval/input/math.jsonl
 export OUTPUT_BASE_DIR=/eval/output/${EXPERIMENT_ID}
 export INFO_LOG_FILE=${OUTPUT_BASE_DIR}/info.txt
 export TEMPERATURE=0
-python scripts/openrouter_eval.py
+python round_test.sh
 ```
 
-Make sure `OPENROUTER_API_KEY` is set in the environment to allow API access.
+### Example (local)
+
+```bash
+export MODEL_NAME=/path/to/local/model
+export INPUT_PATH=/eval/input/math.jsonl
+export EXPERIMENT_ID=basemodel
+python round_test.sh
+```
+
+When `USE_OPENROUTER=true`, ensure `OPENROUTER_API_KEY` is available in the environment.

--- a/round_test.sh
+++ b/round_test.sh
@@ -1,32 +1,35 @@
 #!/bin/sh
 
 ARRAY=(main zeroshot instruct_format_ja instruct_format_en instruct_format_mix step_by_step_ja step_by_step_en step_by_step_mix roleplay_ja roleplay_en deep_breath_ja deep_breath_en re-read_ja re-read_en re-read_mix echo_ja echo_en step_back_ja)
-number="basemodel"
-model="llm-jp/llm-jp-3-13b-instruct2"
-input="./input/math.jsonl"
-lora=False
-gpu=0.9
-temperature=0
 
-output_home="./output/$number"
+# Experiment configuration
+EXPERIMENT_ID="${EXPERIMENT_ID:-basemodel}"
+MODEL_NAME="${MODEL_NAME:?MODEL_NAME is not set}"
+INPUT_PATH="${INPUT_PATH:-./input/math.jsonl}"
+USE_OPENROUTER="${USE_OPENROUTER:-false}"
 
-if [ -e ${output_home} ]; then
-  echo "${output_home}は存在します。"
+# Optional parameters for local inference
+lora=${ENABLE_LORA:-False}
+gpu=${GPU_MEMORY_UTILIZATION:-0.9}
+temperature=${TEMPERATURE:-0}
+
+OUTPUT_BASE_DIR="${OUTPUT_BASE_DIR:-./output/${EXPERIMENT_ID}}"
+INFO_LOG_FILE="${INFO_LOG_FILE:-${OUTPUT_BASE_DIR}/info.txt}"
+
+mkdir -p "${OUTPUT_BASE_DIR}"
+
+if [ "${USE_OPENROUTER}" = "true" ]; then
+  python scripts/openrouter_eval.py
 else
-  mkdir "${output_home}"
-  echo "${output_home}を作成しました。"
+  for arg in ${ARRAY[@]}
+  do
+    output_dir="${OUTPUT_BASE_DIR}/${arg}-${EXPERIMENT_ID}.jsonl"
+    python scripts/$arg.py $MODEL_NAME \
+      --input_path=$INPUT_PATH \
+      --output_path=$output_dir \
+      --enable_lora=$lora \
+      --gpu_memory_utilization=$gpu \
+      --temperature=$temperature
+    python scripts/eval.py --input_path=$output_dir --log_path=$INFO_LOG_FILE
+  done
 fi
-
-INFO_LOG_FILE="${output_home}/info.txt"
-
-for arg in ${ARRAY[@]}
-do
-  output_dir="${output_home}/${arg}-${number}.jsonl"
-  python scripts/$arg.py $model \
-  --input_path=$input \
-  --output_path=$output_dir \
-  --enable_lora=$lora \
-  --gpu_memory_utilization=$gpu \
-  --temperature=$temperature
-  python scripts/eval.py --input_path=$output_dir --log_path=$INFO_LOG_FILE
-done


### PR DESCRIPTION
## Summary
- update README with env vars, examples and USE_OPENROUTER
- update `round_test.sh` to use `MODEL_NAME` and switch to `openrouter_eval.py` when `USE_OPENROUTER=true`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_687d05e9d4ac8329aa8d2901f990d554